### PR TITLE
Update install-ipfs-linux.sh

### DIFF
--- a/install-ipfs-linux.sh
+++ b/install-ipfs-linux.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # This script installs IPFS.
-# https://github.com/ipfs/kubo/releases/download/v0.29.0/kubo_v0.29.0_linux-arm64.tar.gz
+# For Linux or Darwin, update URLs accordingly.
+# https://github.com/ipfs/kubo/releases/download/v0.29.0/kubo_v0.29.0_linux-arm64.tar.gz 
 # https://github.com/ipfs/kubo/releases/download/v0.29.0/kubo_v0.29.0_darwin-amd64.tar.gz
 
 # Navigate to the directory where the script resides
@@ -11,12 +12,24 @@ cd $DIR
 echo "Starting IPFS installation process..."
 echo "======================================="
 
-echo "1. Downloading IPFS package - Linux AMD64"
-# Download the IPFS package
+# Define the IPFS version and platform
 IPFS_VERSION="v0.29.0"
-IPFS_PACKAGE="kubo_${IPFS_VERSION}_linux-amd64.tar.gz"
-IPFS_URL="https://github.com/ipfs/kubo/releases/download/${IPFS_VERSION}/${IPFS_PACKAGE}"
+PLATFORM=$(uname -s)
+ARCHITECTURE=$(uname -m)
 
+if [[ "$PLATFORM" == "Darwin" && "$ARCHITECTURE" == "arm64" ]]; then
+    IPFS_PACKAGE="kubo_${IPFS_VERSION}_darwin-arm64.tar.gz"
+    IPFS_URL="https://github.com/ipfs/kubo/releases/download/${IPFS_VERSION}/${IPFS_PACKAGE}"
+elif [[ "$PLATFORM" == "Linux" && "$ARCHITECTURE" == "x86_64" ]]; then
+    IPFS_PACKAGE="kubo_${IPFS_VERSION}_linux-amd64.tar.gz"
+    IPFS_URL="https://github.com/ipfs/kubo/releases/download/${IPFS_VERSION}/${IPFS_PACKAGE}"
+else
+    echo "   - Error: Unsupported platform ${PLATFORM} ${ARCHITECTURE}."
+    exit 1
+fi
+
+echo "1. Downloading IPFS package from $IPFS_URL"
+# Download the IPFS package
 curl -fsSL $IPFS_URL -o $IPFS_PACKAGE
 if [[ $? -ne 0 ]]; then
     echo "   - Error: Failed to download IPFS package from $IPFS_URL"
@@ -35,7 +48,8 @@ echo "   - IPFS package extracted successfully"
 
 echo "3. Installing IPFS"
 # Run the installation script
-sudo ./kubo/install.sh
+cd ./kubo
+sudo ./install.sh
 if [[ $? -ne 0 ]]; then
     echo "   - Error: Failed to install IPFS"
     exit 1


### PR DESCRIPTION
I added platform (Linux or Darwin) and architecture (x86_64 or arm64) detection to ensure that the script downloads and installs the appropriate IPFS package based on the user's system.
This allows support for different platforms. For example:
If the system is Darwin (macOS) with arm64 architecture, the appropriate IPFS package for that platform will be downloaded.
If the system is Linux with x86_64 architecture, the correct package for Linux will be downloaded.
In case of an unsupported platform/architecture, an error message will be shown.
