### PR TITLE
Add Support for Two New Models in User Task Mode

### DIFF
--- a/dist/.env-example
+++ b/dist/.env-example
@@ -95,6 +95,7 @@ LLM_OPTION_GPU_THRESHOLD=-1
 # CPU Configuration
 #-------------------------------------------------------------------------------
 # Number of CPU threads to use (-1 for auto)
+# 99999 for maximum
 LLM_OPTION_CPU_THREADS=-1
 
 # Docker GPU Configuration
@@ -133,6 +134,18 @@ DOCKER_IPFS=0 # Not used
 AGENT_MINER_DOCKER_LLM=1    # Not used
 # Set to 1 to automatically start LLM Docker container
 AGENT_MINER_DOCKER_LLM_START=1    # Not used
+# Custom container image for LLM (only used with ENABLE_DEDICATED_NODE=1)
+# Available models for dedicated nodes:
+# - DeepSeek-R1-Distill-Llama-8B-Q4_K_M
+# - Meta-Llama-3.1-8B-Instruct.Q4_K_M
+LLM_CONTAINER_IMAGE=""
+
+# Subprocess model for LLM (only used when Docker is not used and ENABLE_DEDICATED_NODE=0)
+# Available models:
+# - llava-v1.5-7b-q4
+# - DeepSeek-R1-Distill-Llama-8B-Q4_K_M
+# - Meta-Llama-3.1-8B-Instruct.Q4_K_M
+LLM_SUBPROCESS_MODEL=""
 
 # Agent Role Configuration
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for the following models in User Task Mode (dedicated node), available in both subprocess and Docker modes:

- DeepSeek-R1-Distill-Llama-8B-Q4_K_M
- Meta-Llama-3.1-8B-Instruct.Q4_K_M

Also ensures continued support for llava-v1.5-7b-q4 as the default benchmark model.

This extends flexibility for task-specific deployments and prepares for broader model support across use cases.