### PR TITLE
Add Per-Model GPU Thresholds & Memory Index Buffer + GPU/Dynamic Model Loading/Switching Fixes

### DIFF
--- a/dist/.env-example
+++ b/dist/.env-example
@@ -92,6 +92,22 @@ LLM_OPTION_GPU=0
 # Threshold for GPU layers (-1 for auto)
 LLM_OPTION_GPU_THRESHOLD=-1
 
+# Model-specific GPU thresholds (0-11) - Override general GPU threshold for specific models
+# Only used when LLM_MEMORY_INDEX_DYNAMIC_LOADING=1 or worker manager is enabled
+# -1 for auto, 0 to disable GPU for that model, positive number for specific threshold
+LLM_OPTION_MODEL_GPU_THRESHOLD_0=-1   # llava-v1.5-7b-q4
+LLM_OPTION_MODEL_GPU_THRESHOLD_1=-1   # DeepSeek-R1-Distill-Llama-8B-Q4_K_M
+LLM_OPTION_MODEL_GPU_THRESHOLD_2=-1   # Meta-Llama-3.1-8B-Instruct.Q4_K_M
+LLM_OPTION_MODEL_GPU_THRESHOLD_3=-1   # Qwen_QwQ-32B-Q4_K_M
+LLM_OPTION_MODEL_GPU_THRESHOLD_4=-1   # Mistral-7B-Instruct-v0.3.Q4_0
+LLM_OPTION_MODEL_GPU_THRESHOLD_5=-1   # granite-3.2-8b-instruct-Q4_K_M
+LLM_OPTION_MODEL_GPU_THRESHOLD_6=-1   # Qwen2.5-7B-Instruct-1M-Q4_K_M
+LLM_OPTION_MODEL_GPU_THRESHOLD_7=-1   # google_gemma-3-4b-it-Q6_K
+LLM_OPTION_MODEL_GPU_THRESHOLD_8=-1   # Qwen_Qwen3-4B-Q8_0
+LLM_OPTION_MODEL_GPU_THRESHOLD_9=-1   # google_gemma-3-12b-it-Q4_K_M
+LLM_OPTION_MODEL_GPU_THRESHOLD_10=-1  # DeepSeek-R1-Distill-Qwen-14B-Q4_K_M
+LLM_OPTION_MODEL_GPU_THRESHOLD_11=-1  # Qwen2.5-Coder-14B-Instruct-Q4_K_M
+
 # CPU Configuration
 #-------------------------------------------------------------------------------
 # Number of CPU threads to use (-1 for auto)
@@ -164,6 +180,10 @@ LLM_CONTAINER_IMAGE=""
 # 5 - granite-3.2-8b-instruct-Q4_K_M: Granite 3.2 8B Instruct Q4_K_M
 # 6 - Qwen2.5-7B-Instruct-1M-Q4_K_M: Qwen 2.5 7B Instruct 1M Q4_K_M
 # 7 - google_gemma-3-4b-it-Q6_K: Google Gemma 3 4B Q6_K
+# 8 - Qwen_Qwen3-4B-Q8_0: Qwen Qwen3 4B Q8_0
+# 9 - google_gemma-3-12b-it-Q4_K_M: Google Gemma 3 12B Q4_K_M
+# 10 - Qwen_Qwen3-4B-Q8_0: Qwen Qwen3 4B Q8_0
+# 11 - google_gemma-3-12b-it-Q4_K_M: Google Gemma 3 12B Q4_K_M
 LLM_SUBPROCESS_MODEL=""
 
 # Agent Role Configuration
@@ -208,6 +228,10 @@ LLM_WORKER_CONTAINER_NAME_PREFIX=""
 #-------------------------------------------------------------------------------
 # Set to 1 to enable dynamic loading of memory indexes for LLM
 LLM_MEMORY_INDEX_DYNAMIC_LOADING=1
+
+# LLM Memory Index Buffer Percentage
+# Percentage of additional memory buffer to add to model size calculations (default: 20%)
+LLM_MEMORY_INDEX_BUFFER_PERCENTAGE=20
 
 # Polling Intervals
 #-------------------------------------------------------------------------------

--- a/dist/.env-example
+++ b/dist/.env-example
@@ -142,6 +142,14 @@ AGENT_MINER_DOCKER_LLM_START=1    # Not used
 # - DeepSeek-R1-Distill-Llama-8B-Q4_K_M
 # - Meta-Llama-3.1-8B-Instruct.Q4_K_M
 # - Qwen_QwQ-32B-Q4_K_M
+# - Mistral-7B-Instruct-v0.3.Q4_0
+# - granite-3.2-8b-instruct-Q4_K_M
+# - Qwen2.5-7B-Instruct-1M-Q4_K_M
+# - google_gemma-3-4b-it-Q6_K
+# - Qwen_Qwen3-4B-Q8_0
+# - google_gemma-3-12b-it-Q4_K_M
+# - DeepSeek-R1-Distill-Qwen-14B-Q4_K_M
+# - Qwen2.5-Coder-14B-Instruct-Q4_K_M
 LLM_CONTAINER_IMAGE=""
 
 # Subprocess model for LLM (only used when Docker is not used and ENABLE_DEDICATED_NODE=0)


### PR DESCRIPTION
**Introduced per-model GPU threshold flags (LLM_OPTION_MODEL_GPU_THRESHOLD_X)**
- -1 = auto (default)
- 0 = disable GPU for that model
- positive integer = specific GPU threshold

**Added configurable memory buffer percentage (LLM_MEMORY_INDEX_BUFFER_PERCENTAGE, default 20%) to improve accuracy of VRAM usage checks during model loading**

Prevents nodes from attempting to load models beyond actual GPU capacity
Improves reliability of dynamic model loading and reduces crash risks

**Additionally lot of bug fixes around GPU/Dynamic Model Loading & Switching Fixes.**