### PR TITLE
Make delegate execute normal task requests while preserving explicit planner mode

### DIFF
--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:315b2e78c568184b6c49ed376cd9fac7abcbfc0e7f33a31bcf308b918bb500cf
-size 126406648
+oid sha256:f92673c6d4d7da3d554ab0b4f4b2ecfa3d37dad141f843022e0a5a733ad755bc
+size 126408040

--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f92673c6d4d7da3d554ab0b4f4b2ecfa3d37dad141f843022e0a5a733ad755bc
-size 126408040
+oid sha256:421ab7e3942c89d56f43d6c9f1d4c00ea18f14d340afbf44c1dcb1f2be647895
+size 126411952


### PR DESCRIPTION
Updates v2/v3 delegate so normal task-style calls can return actual task output, instead of always returning a delegation plan. Explicit planner-style requests still preserve the old behavior when evaluation_mode, task_type, or planner-oriented inputs clearly ask for planning. This keeps the change isolated to delegate v2/v3 and makes web fetch + summarize style requests behave more naturally.