### PR TITLE
Router Node - Add TaskEnded wait mode for completions

### DIFF
--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3cee1a94f1c121cb70c4cdbe7c8dd797505cb8aca1a52f0d5f432d1059f13fc
+oid sha256:3b56da860dc5d0da9fb4e1ac31623acaca6b1d21bb64b75c34f1e50b16fe57f4
 size 126413640

--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:421ab7e3942c89d56f43d6c9f1d4c00ea18f14d340afbf44c1dcb1f2be647895
-size 126411952
+oid sha256:d3cee1a94f1c121cb70c4cdbe7c8dd797505cb8aca1a52f0d5f432d1059f13fc
+size 126413640


### PR DESCRIPTION
Adds an opt-in completion flag that skips early return on TaskCommitted and waits for TaskEnded instead. This enables the router to pull all committed task results through the batch web3 path, including offchain-backed results, and prepares the completion flow for later consensus aggregation.