### PR TITLE
Quality Oracle - Add stateless inference quality oracle checks for ephemeral sessions

### DIFF
--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b56da860dc5d0da9fb4e1ac31623acaca6b1d21bb64b75c34f1e50b16fe57f4
-size 126413640
+oid sha256:695d83d5fa23f4f85c1d19b1eff1c3b5b7d7705dacebe3d2c9b66862e0618977
+size 126997064


### PR DESCRIPTION
This adds a minimal stateless quality-oracle flow for ephemeral sessions. The oracle now picks a redundancy session based on pool size, submits a fixed quality-check prompt, waits for task completion, pulls per-miner results from chain, and verifies success using dashboard-style signals such as ack/precommit/commit timestamps, result presence, and hash match. It also improves the printed check output so we can see per-miner status, timing, and basic pass/fail health without adding persistence yet.