### PR TITLE
Add model 73-77 build targets and runtime registrations

### DIFF
--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:695d83d5fa23f4f85c1d19b1eff1c3b5b7d7705dacebe3d2c9b66862e0618977
-size 126997064
+oid sha256:ef103fa78a954c93135ed897a30eae7c79c17f7413eb132b9fdd310aacb0d24d
+size 127004624


### PR DESCRIPTION
- add new model Dockerfiles and build scripts for model IDs `73-77`
- register new CPU/GPU model IDs in `llm.py` for `gemma4:e4b`, `gemma4:26b`, `gemma4:31b`, `qwen3.6:27b`, and `qwen3.6:35b`
- wire the same model IDs so runtime container selection resolves to `cts-llm-73` through `cts-llm-77`
- extend the docker model range cap from `67` to `77`
- keep the change confined to model/build registration paths without altering unrelated runtime behavior