### PR TITLE
Add env-based multi-session round-robin routing for v1/v2/v3 completions

### DIFF
--- a/dist/.env-example
+++ b/dist/.env-example
@@ -236,6 +236,32 @@ X402_ROUTER_NODE_FACTCHECK_SESSION_ID=""
 X402_ROUTER_NODE_FACTCHECK_SINGLE_SESSION_ID=""
 X402_ROUTER_NODE_FACTCHECK_CONSENSUS_SESSION_ID=""
 
+# Fixed predefined session mapping for /api/v3/delegate and /api/v3/validate.
+# v3 is additive and isolated from existing v1/v2 behavior.
+# The caller chooses consensus.replicas = 1, 3, or 5, and the router selects
+# the matching predefined session ID below.
+#
+# Format:
+#   single session ID per redundancy tier
+#
+# Example mapping style:
+#   - testnet1a router0 cortensor.app -> 1=115, 3=116, 5=117
+#   - testnet1a router1 cortensor.app -> 1=119, 3=120, 5=121
+#   - testnet1a router0 bardiel.app   -> 1=123, 3=124, 5=125
+#   - testnet1a router1 bardiel.app   -> 1=127, 3=128, 5=129
+#
+# Each mapped session should already be configured internally for the intended
+# node redundancy / consensus behavior of that tier.
+# Current rollout uses:
+#   - /api/v3/delegate -> routes to the mapped session and returns delegate output
+#   - /api/v3/validate -> routes to the mapped session and returns validation output
+ROUTER_V3_DELEGATE_SESSION_IDS_1="301"
+ROUTER_V3_DELEGATE_SESSION_IDS_3="302"
+ROUTER_V3_DELEGATE_SESSION_IDS_5="305"
+ROUTER_V3_VALIDATE_SESSION_IDS_1="401"
+ROUTER_V3_VALIDATE_SESSION_IDS_3="402"
+ROUTER_V3_VALIDATE_SESSION_IDS_5="405"
+
 # x402 Trial Configuration (REST + MCP trial tools)
 #-------------------------------------------------------------------------------
 # Set to 1 to enable trial endpoints (/api/v1|v2/trial/*), 0 to disable.
@@ -260,6 +286,45 @@ X402_ROUTER_NODE_TRIAL_FACTCHECK_CONSENSUS_SESSION_ID=""
 TAVILY_API_KEY=""
 # Tavily endpoint override (default shown).
 TAVILY_API_URL="https://api.tavily.com/search"
+
+# Off-chain Storage (S3 / Linode Object Storage)
+#-------------------------------------------------------------------------------
+# Off-chain payload storage.
+#
+# Current behavior is split by URN version:
+#
+#   v1 / v2:
+#   - keeps using the built-in network-owned storage backend
+#   - existing behavior is preserved to avoid regression
+#   - example URN:
+#   urn:blob:v1:s3:akamai:<bucket>:<file_name>
+#
+#   v3:
+#   - used for the newer dedicated-node off-chain storage path
+#   - router/miner resolve the real backend from a backend map and emit URNs like:
+#     urn:blob:v3:s3:akamai:<backend_index>:<bucket>:<file_name>
+#   - dedicated router + dedicated miner can use the same custom storage creds
+#   - current rollout is intended for dedicated-node sessions
+#
+# These OFFCHAIN_S3_* env vars are for the v3/custom backend path.
+# They do not change the current v1/v2 network-owned storage flow.
+#
+# Router/miner v3 behavior:
+#   - OFFCHAIN_S3_REGION / OFFCHAIN_S3_ENDPOINT_URL identify the custom backend
+#   - OFFCHAIN_S3_ACCESS_KEY / OFFCHAIN_S3_SECRET_KEY are used for S3 access
+#   - OFFCHAIN_S3_BUCKET_NAME is the default bucket for v3 writes
+#   - if a route/tool explicitly passes `group`, that overrides the default
+#     bucket for that write
+#   - reads use the bucket from the URN itself
+#
+# If these env vars are left unset, v3 falls back to the current built-in
+# defaults shown below. In that case the custom v3 backend effectively resolves
+# to the same network-owned storage backend.
+OFFCHAIN_S3_REGION="us-east-1"
+OFFCHAIN_S3_ACCESS_KEY="JU52N4B1QPJRDH77Q00J"
+OFFCHAIN_S3_SECRET_KEY="rkx4aNeuXcmSuEUYUtuvFyAJMFVq2DSnW7c2jYHl"
+OFFCHAIN_S3_ENDPOINT_URL="https://us-east-1.linodeobjects.com"
+OFFCHAIN_S3_BUCKET_NAME="test0"
 
 # Private Inference
 #-------------------------------------------------------------------------------

--- a/dist/.env-example
+++ b/dist/.env-example
@@ -147,6 +147,15 @@ ROUTER_MCP_FACTCHECK_CONSENSUS_SESSION_ID=""
 # Global fallback `session_id` when a tool-specific key above is not set
 ROUTER_MCP_DEFAULT_SESSION_ID=""
 
+# Standard REST completion multi-session routing (non-x402)
+#-------------------------------------------------------------------------------
+# Optional session pool for /api/v1|v2|v3/completions when the caller omits
+# session_id. The router will rotate through this list using round-robin.
+# Explicit path or payload session_id still takes precedence when provided.
+# Example:
+# ROUTER_COMPLETION_SESSION_IDS="120,121,122"
+ROUTER_COMPLETION_SESSION_IDS=""
+
 # MCP SSE (Legacy) Server for Router (HTTP + Server-Sent Events)
 #-------------------------------------------------------------------------------
 # Set to 1 to enable the legacy MCP SSE server inside the router, 0 to disable

--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef103fa78a954c93135ed897a30eae7c79c17f7413eb132b9fdd310aacb0d24d
-size 127004624
+oid sha256:4f7952e8231a4983c8dbd1c755bd9d9556e35918537ed6fce56a7d2befeb6765
+size 127006064

--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f7952e8231a4983c8dbd1c755bd9d9556e35918537ed6fce56a7d2befeb6765
-size 127006064
+oid sha256:309ff4632eee314dd14c896d0ffec7ceaa3e64d6f8a3455c2959334a3d007596
+size 127006032


### PR DESCRIPTION
- add a shared completion session resolver backed by `ROUTER_COMPLETION_SESSION_IDS`
- support router-side round-robin session selection when `session_id` is omitted
- preserve existing precedence so explicit path or payload `session_id` still wins
- wire the resolver into `v1`, `v2`, and `v3` completion flows
- ensure `v2` and `v3` resolve session before offchain/encryption-aware payload preparation
- keep `x402`, `delegate`, `validate`, and other non-completion routing paths unchanged