### PR TITLE
Add models 78 and 79

### DIFF
--- a/dist/cortensord
+++ b/dist/cortensord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9430a090fd209a013712c52c1ac0db7d0aa33b6a4afad66aa210ef4931277c3
-size 127015536
+oid sha256:c7b5fb8d2925329ff2b6c6e1400e5a14143ea589a507dca14f9a7626adf6415a
+size 127016656


### PR DESCRIPTION
Adds support and Docker build assets for:

- `muse-glimmer:30b` — model 78
- `nemotron-3.5-lightning:30b` — model 79